### PR TITLE
Fix build error on VS2019 (IWYU std::stirng)

### DIFF
--- a/Source2Gen/shared/Schema.hpp
+++ b/Source2Gen/shared/Schema.hpp
@@ -7,6 +7,7 @@
 // So, reversing had to be done on some of these to figure out their unknown members.
 
 #include <vector>
+#include <string>
 
 #include "Utility.hpp"
 


### PR DESCRIPTION
Fix the operator std::string() in there.